### PR TITLE
Correct Tweepy Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ This is a work in progress, so bear with me as I make it work.
 # About emojihaiku  
 
 - Uses the [emoji](https://pypi.python.org/pypi/emoji) python library 
-- Uses [Tweepy](tweepy.org) 
+- Uses [Tweepy](http://www.tweepy.org/) 
 - Inspired by Liza Daly's [I Luv Recipes](https://github.com/lizadaly/i_luv_recipes) bot. 


### PR DESCRIPTION
If not from the protocol, GitHub takes the link as relative.
